### PR TITLE
Support uploading files

### DIFF
--- a/api_taster.gemspec
+++ b/api_taster.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'sass-rails'
   s.add_dependency 'bootstrap-sass', '~> 2.1'
   s.add_dependency 'redcarpet'
+  s.add_dependency 'remotipart', '~> 1.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov'

--- a/app/assets/javascripts/api_taster/application.js
+++ b/app/assets/javascripts/api_taster/application.js
@@ -12,5 +12,6 @@
 //
 //= require jquery
 //= require jquery_ujs
+//= require jquery.remotipart
 //= require bootstrap
 //= require_tree .

--- a/app/views/api_taster/routes/_param_form_element.html.erb
+++ b/app/views/api_taster/routes/_param_form_element.html.erb
@@ -1,6 +1,10 @@
 <div class="control-group">
   <label class="control-label" for="<%= label %>"><%= defined?(label_text) ? label_text : label %></label>
   <div class="controls">
-    <input type="text" name="<%= label %>" value="<%= value %>"></input>
+    <% if value === :file %>
+        <input type="file" name="<%= label %>" ></input>
+    <% else %>
+        <input type="text" name="<%= label %>" value="<%= value.to_s %>"></input>
+    <% end %>
   </div>
 </div>

--- a/lib/api_taster.rb
+++ b/lib/api_taster.rb
@@ -1,5 +1,6 @@
 require 'jquery-rails'
 require 'bootstrap-sass'
+require 'remotipart'
 require 'active_support/dependencies'
 require 'api_taster/engine'
 require 'api_taster/route'

--- a/lib/api_taster/form_builder.rb
+++ b/lib/api_taster/form_builder.rb
@@ -52,7 +52,7 @@ module ApiTaster
         :locals  => {
           :label      => "#{print_labels(parent_labels)}#{label}",
           :label_text => label,
-          :value      => value.to_s
+          :value      => value
         }
       )
     end

--- a/spec/form_builder_spec.rb
+++ b/spec/form_builder_spec.rb
@@ -12,6 +12,7 @@ module ApiTaster
     let(:builder) do
       FormBuilder.new({
         :hello => 'world',
+        :content => :file,
         :user => {
           :name => 'Fred',
           :comment => {
@@ -41,6 +42,10 @@ module ApiTaster
     context "data types" do
       it "does strings" do
         builder.html.should match('value="world"')
+      end
+
+      it "does files" do
+        builder.html.should match('<input type="file" name="content" ></input>')
       end
 
       it "does numbers" do


### PR DESCRIPTION
This patch supports uploading files.

To upload file, you should write routes.rb like below:

``` ruby
ApiTaster.routes do
   post '/items', {
        :item => {
           :title => 'test',
           :content => :file  # this generates file upload form.
         }
    }
end
```
