### PR TITLE
Do not ignore if route is a constraint

### DIFF
--- a/lib/api_taster/route.rb
+++ b/lib/api_taster/route.rb
@@ -35,7 +35,6 @@ module ApiTaster
         end
 
         route_set.routes.each do |route|
-          next if route.app.is_a?(ActionDispatch::Routing::Mapper::Constraints)
           next if route.app.is_a?(Sprockets::Environment)
           next if route.app == ApiTaster::Engine
 


### PR DESCRIPTION
Hi,

I found out that routes that are defined within constraint block don't get displayed in missing definitions because of [this line](https://github.com/felipeelias/api_taster/pull/new/fix-routes-with-constraints#L0L38).

Since the #discover_rack_app method looks inside the constraint for the rack app, I think this line is not necessary.

Let me know how can I improve this P.R. with tests.
