### PR TITLE
Add route collector to ApiTaster

### DIFF
--- a/lib/api_taster.rb
+++ b/lib/api_taster.rb
@@ -6,13 +6,14 @@ require 'api_taster/engine'
 require 'api_taster/route'
 require 'api_taster/mapper'
 require 'api_taster/form_builder'
+require 'api_taster/route_collector'
 
 module ApiTaster
   mattr_accessor :global_params
   self.global_params = {}
 
   def self.routes(&block)
-    Route.mappings = Proc.new { block }
+    ApiTaster::RouteCollector.routes << block
   end
 
   class Exception < ::Exception; end

--- a/lib/api_taster/route.rb
+++ b/lib/api_taster/route.rb
@@ -10,7 +10,7 @@ module ApiTaster
 
     class << self
 
-      def map_routes
+      def map_routes(path = "#{Rails.root}/app/api_tasters")
         self.route_set            = Rails.application.routes
         self.supplied_params      = {}
         self.obsolete_definitions = []
@@ -20,7 +20,8 @@ module ApiTaster
         normalise_routes!
 
         begin
-          Mapper.instance_eval(&self.mappings.call)
+          ApiTaster::RouteCollector.collect!(path)
+          Mapper.instance_eval(&self.mappings)
         rescue
           Route.mappings = {}
         end

--- a/lib/api_taster/route_collector.rb
+++ b/lib/api_taster/route_collector.rb
@@ -1,0 +1,18 @@
+module ApiTaster
+  class RouteCollector
+    cattr_accessor :routes
+    self.routes = []
+
+    class << self
+      def collect!(path)
+        self.routes = []
+        Dir["#{path}/**/*.rb"].each { |file| load(file) }
+        Route.mappings = Proc.new do
+          for route in RouteCollector.routes
+              instance_eval(&route)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/dummy/api_tasters/test1.rb
+++ b/spec/dummy/api_tasters/test1.rb
@@ -1,0 +1,4 @@
+ApiTaster.routes do
+  post '/dummy_users'
+  post '/dummy_users', { :hello => 'world' }, { :meta => 'data' }
+end

--- a/spec/dummy/api_tasters/test2.rb
+++ b/spec/dummy/api_tasters/test2.rb
@@ -1,0 +1,3 @@
+ApiTaster.routes do
+  get '/dummy_users/:id', :id => 1
+end

--- a/spec/dummy/app/api_tasters/global_params/test.rb
+++ b/spec/dummy/app/api_tasters/global_params/test.rb
@@ -1,0 +1,3 @@
+ApiTaster.routes do
+  get '/dummy_users/:id', :id => 1
+end

--- a/spec/dummy/app/api_tasters/mapper/test1.rb
+++ b/spec/dummy/app/api_tasters/mapper/test1.rb
@@ -1,0 +1,10 @@
+ApiTaster.routes do
+  get '/dummy_route'
+  desc "Dummy user ID"
+  get '/dummy_users/:id', :id => 1
+  post '/dummy_users'
+  post '/dummy_users', { :hello => 'world' }, { :meta => 'data' }
+  put '/dummy_users/:id', :id => 2
+  delete '/dummy_users/:id', :id => 3
+  patch '/dummy_users/:id', :id => 4
+end

--- a/spec/dummy/app/api_tasters/route_collector/test1.rb
+++ b/spec/dummy/app/api_tasters/route_collector/test1.rb
@@ -1,0 +1,4 @@
+ApiTaster.routes do
+  post '/dummy_users'
+  post '/dummy_users', { :hello => 'world' }, { :meta => 'data' }
+end

--- a/spec/dummy/app/api_tasters/route_collector/test2.rb
+++ b/spec/dummy/app/api_tasters/route_collector/test2.rb
@@ -1,0 +1,3 @@
+ApiTaster.routes do
+  get '/dummy_users/:id', :id => 1
+end

--- a/spec/mapper_spec.rb
+++ b/spec/mapper_spec.rb
@@ -2,19 +2,30 @@ require 'spec_helper'
 
 module ApiTaster
   describe Mapper do
+    context "#global_params" do
+      before(:all) do
+        ApiTaster.global_params = { :foo => 'bar' }
+
+        Route.map_routes "#{Rails.root}/app/api_tasters/global_params"
+      end
+
+      it "merges params" do
+        route = Route.find_by_verb_and_path(:get, '/dummy_users/:id')
+
+        Route.supplied_params[route[:id]].should == [{ :foo => 'bar', :id => 1 }]
+      end
+    end
+
     context "non-existing routes" do
       before(:all) do
+        ApiTaster.global_params = {}
         routes = ActionDispatch::Routing::RouteSet.new
         routes.draw do
           get '/awesome_route' => 'awesome#route'
         end
 
-        ApiTaster.routes do
-          get '/dummy_route'
-        end
-
         Route.route_set = routes
-        Route.map_routes
+        Route.map_routes "#{Rails.root}/app/api_tasters/mapper"
       end
 
       it "records obsolete definitions" do
@@ -30,36 +41,8 @@ module ApiTaster
       end
     end
 
-    context "#global_params" do
-      before(:all) do
-        ApiTaster.global_params = { :foo => 'bar' }
-
-        ApiTaster.routes do
-          get '/dummy_users/:id', :id => 1
-        end
-
-        Route.map_routes
-      end
-
-      it "merges params" do
-        route = Route.find_by_verb_and_path(:get, '/dummy_users/:id')
-
-        Route.supplied_params[route[:id]].should == [{ :foo => 'bar', :id => 1 }]
-      end
-    end
-
     before(:all) do
-      ApiTaster.routes do
-        desc "Dummy user ID"
-        get '/dummy_users/:id', :id => 1
-        post '/dummy_users'
-        post '/dummy_users', { :hello => 'world' }, { :meta => 'data' }
-        put '/dummy_users/:id', :id => 2
-        delete '/dummy_users/:id', :id => 3
-        patch '/dummy_users/:id', :id => 4
-      end
-
-      Route.map_routes
+      Route.map_routes "#{Rails.root}/app/api_tasters/mapper"
     end
 
     it "gets users" do

--- a/spec/route_collector_spec.rb
+++ b/spec/route_collector_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+module ApiTaster
+  describe RouteCollector do
+    before(:all) do
+      Rails.application.routes.draw do
+        resources :dummy_users
+      end
+      Route.map_routes "#{Rails.root}/app/api_tasters/route_collector"
+    end
+
+    it "gets users" do
+      route = Route.find_by_verb_and_path(:get, '/dummy_users/:id')
+      Route.supplied_params[route[:id]].should == [{ :id => 1 }]
+    end
+
+    it "posts a new user" do
+      route = Route.find_by_verb_and_path(:post, '/dummy_users')
+      Route.supplied_params[route[:id]].should == [{}, { :hello => 'world' }]
+    end
+  end
+end


### PR DESCRIPTION
Currently `ApiTaster.routes` could be called only once, for example if
we will call this code, the only last rule will be applyed.

``` ruby
ApiTaster.routes do
  get '/posts'
end

ApiTaster.routes do
   get '/posts/:post_id/comments'
end
```

We need to store routes in to `app/api_tasters/**/*` and have ability to load them one by one.
Here is how to implement it https://gist.github.com/timurvafin/5082251
