### PR TITLE
Don't force xml for ajax requests

### DIFF
--- a/app/assets/javascripts/api_taster/app.js
+++ b/app/assets/javascripts/api_taster/app.js
@@ -119,8 +119,7 @@ jQuery(function($) {
     window.ajax = $.ajax({
       url: ApiTaster.getSubmitUrl($form),
       type: $form.attr('method'),
-      data: $form.serialize(),
-      dataType: 'xml'
+      data: $form.serialize()
     }).complete(onComplete);
 
     ApiTaster.lastRequest = {};


### PR DESCRIPTION
```
dataType: 'xml'
```

was causing my API to return XML. 

this obviously blew up on JSON.parse in api_taster's app.js.
