### PR TITLE
Change default path for load routes

### DIFF
--- a/lib/api_taster/route.rb
+++ b/lib/api_taster/route.rb
@@ -7,10 +7,12 @@ module ApiTaster
     cattr_accessor :obsolete_definitions
     cattr_accessor :comments
     cattr_accessor :metadata
+    cattr_accessor :path
 
     class << self
-      def map_routes(path = "#{Rails.root}/app/api_tasters")
+      def map_routes
         self.route_set            = Rails.application.routes
+        self.path                 ||= "#{Rails.root}/lib/api_tasters"
         self.supplied_params      = {}
         self.obsolete_definitions = []
         self.comments             = {}
@@ -19,7 +21,7 @@ module ApiTaster
         normalise_routes!
 
         begin
-          ApiTaster::RouteCollector.collect(path)
+          ApiTaster::RouteCollector.collect(self.path)
           Mapper.instance_eval(&self.mappings)
         rescue
           Route.mappings = {}

--- a/spec/mapper_spec.rb
+++ b/spec/mapper_spec.rb
@@ -5,8 +5,8 @@ module ApiTaster
     context "#global_params" do
       before(:all) do
         ApiTaster.global_params = { :foo => 'bar' }
-
-        Route.map_routes "#{Rails.root}/app/api_tasters/global_params"
+        Route.path = "#{Rails.root}/app/api_tasters/global_params"
+        Route.map_routes
       end
 
       it "merges params" do
@@ -25,7 +25,8 @@ module ApiTaster
         end
 
         Route.route_set = routes
-        Route.map_routes "#{Rails.root}/app/api_tasters/mapper"
+        Route.path = "#{Rails.root}/app/api_tasters/mapper"
+        Route.map_routes
       end
 
       it "records obsolete definitions" do
@@ -40,7 +41,8 @@ module ApiTaster
         end
       end
 
-      Route.map_routes "#{Rails.root}/app/api_tasters/mapper"
+      Route.path = "#{Rails.root}/app/api_tasters/mapper"
+      Route.map_routes
     end
 
     it "gets users" do

--- a/spec/route_collector_spec.rb
+++ b/spec/route_collector_spec.rb
@@ -6,7 +6,8 @@ module ApiTaster
       Rails.application.routes.draw do
         resources :dummy_users
       end
-      Route.map_routes "#{Rails.root}/app/api_tasters/route_collector"
+      Route.path = "#{Rails.root}/app/api_tasters/route_collector"
+      Route.map_routes
     end
 
     it "gets users" do


### PR DESCRIPTION
This changes to fix this error:

``` ruby
../api_tasters/posts.rb:1:in `<top (required)>': uninitialized constant ApiTaster (NameError)
```

This error is appear, when we run rspec, when in gemfile we did not include gem 'api_taster' to test group.
