### PR TITLE
Add a controller hooking feature

### DIFF
--- a/app/controllers/api_taster/routes_controller.rb
+++ b/app/controllers/api_taster/routes_controller.rb
@@ -1,5 +1,6 @@
 module ApiTaster
   class RoutesController < ApiTaster::ApplicationController
+    ApiTaster.controller_hook(self)
     before_filter :map_routes
     layout false, except: :index
 

--- a/lib/api_taster.rb
+++ b/lib/api_taster.rb
@@ -25,5 +25,21 @@ module ApiTaster
     ApiTaster::RouteCollector.routes << block
   end
 
+  # Controller hooking may used for custom filters, authorizations, etc.
+  # 
+  # Example with adding basic authentication: 
+  #     
+  #     ApiTaster.controller_hook do
+  #       http_basic_authenticate_with name: "admin", password: "123456"
+  #     end
+  # 
+  def self.controller_hook(klass=nil, &block)
+    if block_given?
+      @@controller_hook = Proc.new {|klass| klass.instance_eval(&block) }
+    elsif @@controller_hook && klass
+      @@controller_hook.call(klass)
+    end
+  end
+  
   class Exception < ::Exception; end
 end

--- a/lib/api_taster.rb
+++ b/lib/api_taster.rb
@@ -25,6 +25,8 @@ module ApiTaster
     ApiTaster::RouteCollector.routes << block
   end
 
+  @@controller_hook = nil
+  
   # Controller hooking may used for custom filters, authorizations, etc.
   # 
   # Example with adding basic authentication: 

--- a/spec/controllers/api_taster/routes_controller_spec.rb
+++ b/spec/controllers/api_taster/routes_controller_spec.rb
@@ -61,5 +61,19 @@ module ApiTaster
         end
       end
     end
+        
+    context "when defined ApiTaster.controller_hook" do
+      before do
+        ApiTaster.controller_hook { before_action {|c| c.response.headers['X-Controller-Hook'] = '1'} }
+        ApiTaster.controller_hook(described_class)
+      end
+      
+      it 'applies the hook' do
+        ApiTaster.controller_hook.should.kind_of? Proc
+      
+        get :index, :use_route => :api_taster
+        response.headers.keys.should include('X-Controller-Hook')
+      end
+    end
   end
 end


### PR DESCRIPTION
Allow to define a hook in initializer, which invokes the controller class. This useful when we need to set some custom callbacks. 

Usage exaple (adding basic auth):

``` ruby
# config/initializers/api_taster.rb

ApiTaster.controller_hook do
  http_basic_authenticate_with name: "admin", password: "123456"
end
```
