### PR TITLE
Enable file field serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ if Rails.env.development?
     post '/users', {
       :user => {
         :name => 'Fred',
-        # a file field
+        # a file field, it doesn't have effect in GET request
         :avatar => :file
       }
     }

--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ if Rails.env.development?
 
     post '/users', {
       :user => {
-        :name => 'Fred'
+        :name => 'Fred',
+        # a file field
+        :avatar => :file
       }
     }
 

--- a/app/assets/javascripts/api_taster/app.js
+++ b/app/assets/javascripts/api_taster/app.js
@@ -122,7 +122,7 @@ jQuery(function($) {
     ApiTaster.disableSubmitButton();
     ApiTaster.disableUrlParams();
 
-    window.ajax = $.ajax({
+    var ajaxParams = {
       beforeSend: function(xhr) {
         var headers = ApiTaster.headers;
         for(var l = headers.length, i = 0; i < l; i ++) {
@@ -130,11 +130,18 @@ jQuery(function($) {
         }
       },
       url: ApiTaster.getSubmitUrl($form),
-      type: $form.attr('method'),
-      data: new FormData(e.target),
-      processData: false,
-      contentType: false
-    }).complete(onComplete);
+      type: $form.attr('method')
+    }
+
+    if (!ajaxParams.type || ajaxParams.type.toLowerCase() === 'get' || ajaxParams.type.toLowerCase() === 'head') {
+      ajaxParams.data = $form.serialize()
+    } else {
+      ajaxParams.data = new FormData(e.target)
+      ajaxParams.processData = false
+      ajaxParams.contentType = false
+    }
+
+    window.ajax = $.ajax(ajaxParams).complete(onComplete);
 
     ApiTaster.lastRequest = {};
     ApiTaster.lastRequest.startTime = Date.now();

--- a/app/assets/javascripts/api_taster/app.js
+++ b/app/assets/javascripts/api_taster/app.js
@@ -131,7 +131,9 @@ jQuery(function($) {
       },
       url: ApiTaster.getSubmitUrl($form),
       type: $form.attr('method'),
-      data: $form.serialize()
+      data: new FormData(e.target),
+      processData: false,
+      contentType: false
     }).complete(onComplete);
 
     ApiTaster.lastRequest = {};


### PR DESCRIPTION
Note: `$form.serialize()` doesn't add file fields in the resulting data.
